### PR TITLE
non-doc pieces for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,33 @@ install:
 
 .PHONY: install
 
+AUTOCONFAGE=Makefile.in \
+	aclocal.m4 \
+	ar-lib \
+	compile \
+	config.guess \
+	config.h.in \
+	config.sub \
+	configure \
+	depcomp \
+	install-sh \
+	ltmain.sh \
+	m4/libtool.m4 \
+	m4/ltoptions.m4 \
+	m4/ltsugar.m4 \
+	m4/ltversion.m4 \
+	m4/lt~obsolete.m4 \
+	missing \
+	test-driver
+
 TARBALL=tmdb-$(shell git describe --tags)
 git-tarball:
 	git archive --prefix=$(TARBALL)/ @ >../$(TARBALL).tar
 	cd deps/memkind && git archive --prefix=$(TARBALL)/deps/memkind/ @ >../../memkind.tar
+	cd deps/memkind && git clean -dfx && ./autogen.sh
+	cd deps/memkind/jemalloc && autoconf
+	tar cf memkind-autoconf.tar --transform s,^,$(TARBALL)/, $(addprefix deps/memkind/,$(AUTOCONFAGE) jemalloc/configure)
 	tar -Af ../$(TARBALL).tar memkind.tar
-	rm memkind.tar
+	tar -Af ../$(TARBALL).tar memkind-autoconf.tar
+	rm memkind.tar memkind-autoconf.tar
 	xz ../$(TARBALL).tar

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,11 @@ install:
 	cd src && $(MAKE) $@
 
 .PHONY: install
+
+TARBALL=tmdb-$(shell git describe --tags)
+git-tarball:
+	git archive --prefix=$(TARBALL)/ @ >../$(TARBALL).tar
+	cd deps/memkind && git archive --prefix=$(TARBALL)/deps/memkind/ @ >../../memkind.tar
+	tar -Af ../$(TARBALL).tar memkind.tar
+	rm memkind.tar
+	xz ../$(TARBALL).tar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ TieredMemDB
 ===========
 
 This project is a fork of [Redis](https://redis.io), adapted for systems
-with multiple memory tiers.  New memory technologies include memories that
+with multiple memory tiers. New memory technologies include memories that
 have very high bandwidth at the cost of latency, slower large capacity
 at lower cost, sharing memory among multiple machines in a rack, and so on.
 
@@ -11,20 +11,24 @@ The overall performance of a system can be improved if frequently accessed
 to be readily available in memory (rather than disk or similar slow storage)
 yet is not as critical, may be kept in a slower memory tier.
 
-This README doesn't describe usual usage of Redis.  We assume you already
-have general experience with Redis.
+This README doesn't describe usual usage of Redis. We assume you already
+have general experience with [Redis](https://github.com/redis/redis).
 
 
 Building TieredMemDB
 --------------------
 
 Generally, TieredMemDB is close to vanilla Redis, and can be used on the
-same set of systems.  You can even build without tier support, as all
-functionality of Redis should be left intact.  To actually get the benefits
+same set of systems. You can even build without tier support, as all
+functionality of Redis should be left intact. To actually get the benefits
 of memory tiers, you need the following extra dependencies:
 
-    * ndctl and daxctl
-    * memkind (included in tarballs)
+    * ndctl and daxctl (v66 or later)
+
+When building from git, you also need to check out the memkind submodule,
+and install:
+
+    * autoconf
 
 Building TieredMemDB is as simple as:
 
@@ -34,24 +38,3 @@ As usual, you can -- and probably want to -- confirm the built code works
 well:
 
     % make test
-
-The crux of TieredMemDB is the tiered allocator, which beside `MALLOC=libc`
-and `MALLOC=jemalloc` supported by Redis adds:
-
-    % make MALLOC=memkind
-
-but in release tarballs this is already the default.
-
-
-Rebasing TieredMemDB
---------------------
-
-The set of patches over base Redis that comprises TieredMemDB can be applied
-onto your modified versions of Redis as well.  To do that, or to update
-Redis to a new minor version (because of eg. a security update), you rebase
-the tree available on [GitHub](https://github.com/TieredMemDB/TieredMemDB),
-or ask git to produce a patch, with our branch checked out:
-
-    % git diff 6.2.6 @
-
-which can then be applied via `patch` over, in this case, Redis 6.2.6.

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -98,6 +98,6 @@ memkind: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
 	if ! [ -x memkind/configure ];then cd memkind && ./autogen.sh; fi
 	cd memkind && ARENA_LIMIT=1 MIN_LG_ALIGN=3 ./configure --disable-heap-manager --disable-hwloc
-	cd memkind && $(MAKE)
+	cd memkind && $(MAKE) jemalloc_deps static_lib
 
 .PHONY: memkind

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -96,7 +96,8 @@ jemalloc: .make-prerequisites
 
 memkind: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
-	cd memkind && ./autogen.sh && ARENA_LIMIT=1 MIN_LG_ALIGN=3 ./configure --disable-heap-manager --disable-hwloc
+	if ! [ -x memkind/configure ];then cd memkind && ./autogen.sh; fi
+	cd memkind && ARENA_LIMIT=1 MIN_LG_ALIGN=3 ./configure --disable-heap-manager --disable-hwloc
 	cd memkind && $(MAKE)
 
 .PHONY: memkind


### PR DESCRIPTION
After these commits, a working build of mkdb can be done by untarring and `make`,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tieredmemdb/tieredmemdb/8)
<!-- Reviewable:end -->
