### PR TITLE
Fix slowlog test false positive.

### DIFF
--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -80,9 +80,11 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     }
 
     test {SLOWLOG - can be disabled} {
+        r config set slowlog-max-len 1
         r config set slowlog-log-slower-than 1
         r slowlog reset
-        assert_equal [r slowlog len] 1 
+        r debug sleep 0.2
+        assert_equal [r slowlog len] 1
         r config set slowlog-log-slower-than -1
         r slowlog reset
         r debug sleep 0.2


### PR DESCRIPTION
In fast systems "SLOWLOG RESET" is fast enough to don't be logged even when the time limit is "1" sometimes. Leading to false positives such as:

[err]: SLOWLOG - can be disabled in tests/unit/slowlog.tcl Expected '1' to be equal to '0'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tieredmemdb/tieredmemdb/85)
<!-- Reviewable:end -->
