### PR TITLE
[6.0.16-devel] Add compile and linking security flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ AUTOCONFAGE=Makefile.in \
 	m4/lt~obsolete.m4 \
 	missing
 
-TARBALL=tmdb-$(shell git describe --tags)
+TARBALL=tmdb-redis-$(shell git describe --tags --match "[1-9].[0-9].[0-9]*")
 git-tarball:
 	git archive --prefix=$(TARBALL)/ @ >../$(TARBALL).tar
 	cd deps/memkind && git archive --prefix=$(TARBALL)/deps/memkind/ @ >../../memkind.tar

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,8 +26,18 @@ ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
 endif
 endif
-WARN=-Wall -W -Wno-missing-field-initializers
+WARN=-Wall -W -Wno-missing-field-initializers -Wformat -Wformat-security
 OPT=$(OPTIMIZATION)
+SECURITY_PIC=-fPIE -fPIC
+SECURITY_NO_EXEC=-Wl,-z,relro,-z,now,-z,noexecstack
+SECURITY_FORTIFY_SOURCE=""
+ifneq ($(OPTIMIZATION),-O0)
+	# the -D_FORTIFY_SOURCE flag only works with optimization enabled
+	SECURITY_FORTIFY_SOURCE="-D_FORTIFY_SOURCE=2"
+else
+	$(warning Optimization is required to set _FORTIFY_SOURCE)
+endif
+SECURITY_FLAGS=$(SECURITY_PIC) $(SECURITY_NO_EXEC) $(SECURITY_FORTIFY_SOURCE)
 
 PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin
@@ -70,8 +80,8 @@ endif
 # Override default settings if possible
 -include .make-settings
 
-FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
-FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS) $(SECURITY_FLAGS)
+FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG) $(SECURITY_FLAGS)
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 


### PR DESCRIPTION
The added flags should marginally affect runtime performance

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tieredmemdb/tieredmemdb/103)
<!-- Reviewable:end -->
