### PR TITLE
[6.0.12-devel] Change tarballs naming convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ AUTOCONFAGE=Makefile.in \
 	m4/lt~obsolete.m4 \
 	missing
 
-TARBALL=tmdb-$(shell git describe --tags)
+TARBALL=tmdb-redis-$(shell git describe --tags --match "[1-9].[0-9].[0-9]*")
 git-tarball:
 	git archive --prefix=$(TARBALL)/ @ >../$(TARBALL).tar
 	cd deps/memkind && git archive --prefix=$(TARBALL)/deps/memkind/ @ >../../memkind.tar


### PR DESCRIPTION
- replace prefix 'tmdb' with 'tmdb-redis',
- always search for the newest tag matching the naming, which should reference to
  the latest Redis release commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tieredmemdb/tieredmemdb/183)
<!-- Reviewable:end -->
