### PR TITLE
[3.2] Fix make test failing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,14 +23,7 @@ WARN=-Wall -W -Wno-missing-field-initializers -Wformat -Wformat-security
 OPT=$(OPTIMIZATION)
 SECURITY_PIC=-fPIE -fPIC
 SECURITY_NO_EXEC=-Wl,-z,relro,-z,now,-z,noexecstack
-SECURITY_FORTIFY_SOURCE=""
-ifneq ($(OPTIMIZATION),-O0)
-	# the -D_FORTIFY_SOURCE flag only works with optimization enabled
-	SECURITY_FORTIFY_SOURCE="-D_FORTIFY_SOURCE=2"
-else
-	$(warning Optimization is required to set _FORTIFY_SOURCE)
-endif
-SECURITY_FLAGS=$(SECURITY_PIC) $(SECURITY_NO_EXEC) $(SECURITY_FORTIFY_SOURCE)
+SECURITY_FLAGS=$(SECURITY_PIC) $(SECURITY_NO_EXEC)
 
 PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin


### PR DESCRIPTION
Compilation flag -D_FORTIFY_SOURCE causes TieredMemDB tarballs
to be generated with faults. Tests `make test` fail because of
redis-benchmark not being generated.
This change fixes that issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tieredmemdb/tieredmemdb/231)
<!-- Reviewable:end -->
