### PR TITLE
fix make issue, when compiling with clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
 endif
 endif
-WARN=-Wall -W -Wno-missing-field-initializers -Wformat -Wformat-security -Werror
+WARN=-Wall -W -Wno-unused-command-line-argument -Wno-missing-field-initializers -Wformat -Wformat-security -Werror
 OPT=$(OPTIMIZATION)
 SECURITY_PIC=-fPIE -fPIC
 SECURITY_NO_EXEC=-Wl,-z,relro,-z,now,-z,noexecstack


### PR DESCRIPTION
When compiling with clang, make returned error:
-Wl,-z,relro,-z,now,-z,noexecstack: 'linker' input unused

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TieredMemDB/TieredMemDB/345)
<!-- Reviewable:end -->
